### PR TITLE
fix exists bug

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -269,7 +269,7 @@ class Query {
 			this.lastKey = null;
 		}
 
-		this.query[key] = { $exists: exists || true };
+		this.query[key] = { $exists: (exists === undefined ? true : exists) };
 
 		return this;
 	}


### PR DESCRIPTION
No matter What value is the parameter of the "exists", the value of "this.query[key]['$exists']" is always true