### PR TITLE
Add option to update instead of replace document during save

### DIFF
--- a/lib/mongorito.js
+++ b/lib/mongorito.js
@@ -596,6 +596,11 @@ Model.prototype.update = function (options) {
 	let self = this;
 
 	let attrs = this.attributes;
+	let _id = attrs._id;
+
+	if (options && options.merge) {
+		attrs = { $set: attrs };
+	}
 
 	this.set('updated_at', new Date());
 
@@ -604,7 +609,7 @@ Model.prototype.update = function (options) {
 			return self._runHooks('before', 'update', options);
 		})
 		.then(function (collection) {
-			return collection.update({ _id: attrs._id }, attrs);
+			return collection.update({ _id }, attrs);
 		})
 		.then(function () {
 			return self._runHooks('after', 'update', options);

--- a/test/models.js
+++ b/test/models.js
@@ -73,6 +73,36 @@ test('update `updated_at` attribute', async t => {
 	t.not(prevDate, nextDate);
 });
 
+test('update attribute with merge', async t => {
+	let post = new Post({ title: 'Default title', subtitle: 'Default subtitle' });
+	await post.save();
+
+	let updatedPost = new Post({ _id: post.get('_id'), title: 'Updated title' });
+	await updatedPost.save({ merge: true });
+
+	let posts = await Post.all();
+	t.is(posts.length, 1);
+
+	let createdPost = posts[0];
+	t.is(createdPost.get('title'), 'Updated title');
+	t.is(createdPost.get('subtitle'), 'Default subtitle');
+});
+
+test('update nested attribute with merge', async t => {
+	let post = new Post({ title: 'Default title', author: { name: 'john' } });
+	await post.save();
+
+	let updatedPost = new Post({ _id: post.get('_id'), 'author.name': 'david' });
+	await updatedPost.save({ merge: true });
+
+	let posts = await Post.all();
+	t.is(posts.length, 1);
+
+	let createdPost = posts[0];
+	t.is(createdPost.get('title'), 'Default title');
+	t.is(createdPost.get('author.name'), 'david');
+});
+
 test('remove', async t => {
 	let post = new Post();
 	await post.save();

--- a/test/models.js
+++ b/test/models.js
@@ -92,7 +92,7 @@ test('update nested attribute with merge', async t => {
 	let post = new Post({ title: 'Default title', author: { name: 'john' } });
 	await post.save();
 
-	let updatedPost = new Post({ _id: post.get('_id'), 'author.name': 'david' });
+	let updatedPost = new Post({ _id: post.get('_id'), author: { name: 'david' } });
 	await updatedPost.save({ merge: true });
 
 	let posts = await Post.all();


### PR DESCRIPTION
From what I could determine, any time you call `save()` on an existing document, the update overwrites the document in the DB.

If you just want to update a single attribute in the document you first need to load the entire document into memory and then send the entire document back over the wire with the updates.

This change provides the option to update specific attributes of an existing document.

Example
```JavaScript
const users = await User.where('username', 'user-a').include('height').find()
const user = users[0]
if (user.get('height') !== newHeight) {
  user.set('height', newHeight)
  await user.save({ merge: true })
}
```
I'm not sure `merge` is the best term? Perhaps `update` but that's a bit overloaded?

Refs
- https://docs.mongodb.org/manual/reference/method/db.collection.update/#update-parameter
- https://docs.mongodb.org/manual/reference/operator/update/set/#up._S_set