### PR TITLE
Features/query exclude array issue

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -112,9 +112,7 @@ Query.prototype.include = function (key, value) {
 		fields.forEach(function (key) {
 			self.include(key);
 		});
-	}
-
-	if (is.object(key)) {
+	} else if (is.object(key)) {
 		let fields = key;
 		let keys = Object.keys(fields);
 
@@ -148,9 +146,7 @@ Query.prototype.exclude = function (key, value) {
 		fields.forEach(function (key) {
 			self.exclude(key);
 		});
-	}
-
-	if (is.object(key)) {
+	} else if (is.object(key)) {
 		let fields = key;
 		let keys = Object.keys(fields);
 

--- a/test/queries.js
+++ b/test/queries.js
@@ -397,10 +397,11 @@ test('populate the response', async t => {
 	});
 });
 
-test('find documents and include only selected fields', async t => {
+test('find documents and include only one selected field', async t => {
 	let post = new Post({
 		title: 'San Francisco',
-		featured: true
+		featured: true,
+		published: false
 	});
 
 	await post.save();
@@ -411,15 +412,46 @@ test('find documents and include only selected fields', async t => {
 	t.same(keys, ['_id', 'title']);
 });
 
-test('find documents and exclude selected fields', async t => {
+test('find documents and include only two selected fields', async t => {
 	let post = new Post({
 		title: 'San Francisco',
-		featured: true
+		featured: true,
+		published: false
+	});
+
+	await post.save();
+
+	let posts = await Post.include(['title', 'featured']).find();
+	let attrs = posts[0].toJSON();
+	let keys = Object.keys(attrs);
+	t.same(keys, ['_id', 'title', 'featured']);
+});
+
+test('find documents and exclude one selected field', async t => {
+	let post = new Post({
+		title: 'San Francisco',
+		featured: true,
+		published: false
 	});
 
 	await post.save();
 
 	let posts = await Post.exclude('title').find();
+	let attrs = posts[0].toJSON();
+	let keys = Object.keys(attrs);
+	t.same(keys, ['_id', 'featured', 'published', 'created_at', 'updated_at']);
+});
+
+test('find documents and exclude two selected fields', async t => {
+	let post = new Post({
+		title: 'San Francisco',
+		featured: true,
+		published: false
+	});
+
+	await post.save();
+
+	let posts = await Post.exclude(['title', 'published']).find();
 	let attrs = posts[0].toJSON();
 	let keys = Object.keys(attrs);
 	t.same(keys, ['_id', 'featured', 'created_at', 'updated_at']);


### PR DESCRIPTION
When we give an array of fields to exclude to Query, we receive a MongoError:
```
MongoError: Projection cannot have a mix of inclusion and exclusion.
```
Indeed the key is first recognized as an `Array`, then an `Object` resulting in the query fields being set to:
```
{ '0': 'title', '1': 'published', title: 0, published: 0 }
```

Therefore I suggest to link the array and test object with an `else if` statement so object is not processed if the key has already been recognized as an Array.