### PR TITLE
Features/query populate with options

### DIFF
--- a/lib/mongorito.js
+++ b/lib/mongorito.js
@@ -801,10 +801,7 @@ Model.all = function () {
  */
 
 Model.findOne = function (query) {
-	return this.find(query)
-		.then(function (docs) {
-			return docs[0];
-		});
+	return new Query(this._collection(), this).findOne(query);
 };
 
 
@@ -816,7 +813,7 @@ Model.findOne = function (query) {
  */
 
 Model.findById = function (id) {
-	return this.findOne({ _id: id });
+	return new Query(this._collection(), this).findById(id);
 };
 
 

--- a/lib/query.js
+++ b/lib/query.js
@@ -357,9 +357,8 @@ Query.prototype.count = function (query) {
 
 Query.prototype.find = function (query, options) {
 	let Model = this.model;
-	let self = this;
 
-	this.where(query);
+	query = assign({}, this.query, query);
 
 	// query options
 	options = assign({}, this.options, options);
@@ -368,14 +367,14 @@ Query.prototype.find = function (query, options) {
 	let populate = Object.keys(options.populate);
 
 	// ensure _id is ObjectId
-	if (this.query._id) {
-		this.query._id = toObjectId(this.query._id);
+	if (query._id) {
+		query._id = toObjectId(query._id);
 	}
 
 	// find
 	return this.collection
 		.then(function (collection) {
-			let cursor = collection.find(self.query, options);
+			let cursor = collection.find(query, options);
 
 			return cursor
 				.toArray()

--- a/lib/query.js
+++ b/lib/query.js
@@ -367,7 +367,7 @@ Query.prototype.find = function (query, options) {
 	let populate = Object.keys(options.populate);
 
 	// ensure _id is ObjectId
-	if (query._id) {
+	if (query._id && !is.object(query._id)) {
 		query._id = toObjectId(query._id);
 	}
 
@@ -387,18 +387,23 @@ Query.prototype.find = function (query, options) {
 		.map(function (doc) {
 			return Promise.each(populate, function (key) {
 				let childModel = options.populate[key];
-				let value = doc[key];
+				let idsArray = doc[key];
 
-				if (Array.isArray(value)) {
-					value = Promise.map(value, function (id) {
-						return childModel.findById(id);
+				let promise = childModel.findById(idsArray);
+
+				return promise.then(function (subdocs) {
+					// reorder the received documents as ordered in the IDs Array
+					let orderedDocuments = idsArray.slice();
+					subdocs.map(doc => {
+						let id = toObjectId(doc.get('_id'));
+						for (let index in idsArray) {
+							if (idsArray[index].equals && idsArray[index].equals(id)) {
+								orderedDocuments[index] = doc;
+							}
+						}
 					});
-				} else {
-					value = childModel.findById(value);
-				}
 
-				return value.then(function (value) {
-					doc[key] = value;
+					doc[key] = orderedDocuments;
 				});
 			}).then(function () {
 				return new Model(doc, {
@@ -425,14 +430,18 @@ Query.prototype.findOne = function (query) {
 
 
 /**
- * Find a document by ID
+ * Find documents by ID
  *
- * @param {ObjectID} id - document id
+ * @param {ObjectID} id - document id or Array of document ids
  * @api public
  */
 
 Query.prototype.findById = function (id) {
-	return this.findOne({ _id: id });
+	if (Array.isArray(id)) {
+		let ids = id.map(id => toObjectId(id));
+		return this.find({ _id: { $in: ids } });
+	}
+	return this.findOne({ _id: toObjectId(id) });
 };
 
 

--- a/test/fixtures/comment.js
+++ b/test/fixtures/comment.js
@@ -13,6 +13,7 @@ const chance = require('chance')();
 
 module.exports = function commentFixture() {
 	return {
+		email: chance.email(),
 		body: chance.paragraph()
 	};
 };


### PR DESCRIPTION
### Context
I went on an issue when I was creating a friendship model containing an array of two users. I wanted to be able to populate my friendship model but exclude the personal informations from the user models, like email, password, real name, etc...

### The problem
When I was doing so, calling:
```
var friendship = await Friendship.populate('users', User.exclude(['email', 'real_name']).find(...)
```
I was receiving twice the same user in the users array.

### The bug
In ```Query.prototype.find(query)``` the passed query was overriding the common ```this.query``` object when calling ```this.where(query);``` resulting in all the future queries made from this Query instance to have the same query object.

### Proposition 1
The ```Query.prototype.find(query)``` is now using a query object composed from the scoped one and the argument one to build a query object only valid in the scope of this request. It is then possible to build a generic request with a bunch of query params setted and alter it on the fly.

### Proposition 2 (Commit d0388cb28f84146a7f0bc8893414f0d6dbac92eb)
The population was building parallel requests to retrieve each subdocument independently.
Using the mongo $in operator, it's now requesting all the subdocuments in one request to the database.
Since $in does not respect the requested order, I made sure to reorder the result.
I don't know if there is a better way than $in to force mongo to return documents in order.