### PR TITLE
Adds findManyByIds. Changes find logic to handle findManyByIds.

### DIFF
--- a/lib/mongorito.js
+++ b/lib/mongorito.js
@@ -819,6 +819,17 @@ Model.findById = function (id) {
 	return this.findOne({ _id: id });
 };
 
+/**
+ * Find a document by ID
+ *
+ * @param {ObjectID} id - document id
+ * @api public
+ */
+
+Model.findManyByIds = function (ids) {
+	return new Query(this._collection(), this).findManyByIds(ids);
+};
+
 
 /**
  * Remove documents

--- a/lib/query.js
+++ b/lib/query.js
@@ -368,7 +368,8 @@ Query.prototype.find = function (query, options) {
 	let populate = Object.keys(options.populate);
 
 	// ensure _id is ObjectId
-	if (this.query._id) {
+	// also check to see if typeof is object for $in query
+	if (this.query._id && typeof this.query._id !== 'object') {
 		this.query._id = toObjectId(this.query._id);
 	}
 
@@ -436,6 +437,21 @@ Query.prototype.findById = function (id) {
 	return this.findOne({ _id: id });
 };
 
+/**
+ * Find many documents by ID
+ *
+ * @param [ObjectID] ids - document ids
+ * @api public
+ */
+
+Query.prototype.findManyByIds = function (ids) {
+	// ensure all ids are ObjectIds
+	ids = ids.map(function (id) {
+		return toObjectId(id);
+	});
+
+	return this.find({ _id: { $in: ids } });
+};
 
 /**
  * Remove documents


### PR DESCRIPTION
I came to the unfortunate finding that this query was not possible. 

`ids = ['573008b792c589ee8918318c','573008b892c589ee8918318d','573008b892c589ee8918318e'];
let objects = yield Model.find({
	_id:{$in:ids}
});`

The most frustrating part in all of this was that it was only happening for the _id field. Weird right? That's when I dug a little deeper and saw that you were doing the handy dandy toObjectId in the "find" function. There could be a better implementation of this, however I saw that you were already doing a findById, so I thought : why not make a findManyById as well. 