### PR TITLE
Allowing $in via where('array', ['one', 'two', 'three'])

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -63,7 +63,7 @@ Query.prototype.where = function (key, value) {
 			value = { $regex: value };
 		}
 
-		if(is.array(value)) {
+		if (is.array(value)) {
 			value = { $in: value };
 		}
 

--- a/lib/query.js
+++ b/lib/query.js
@@ -63,6 +63,10 @@ Query.prototype.where = function (key, value) {
 			value = { $regex: value };
 		}
 
+		if(is.array(value)) {
+			value = { $in: value };
+		}
+
 		this.query[key] = value;
 	}
 


### PR DESCRIPTION
If an array is being passed to `where`, it'll use `$in: <array>` as query `value`.