### PR TITLE
Expose mongodb driver for external use

### DIFF
--- a/lib/mongorito.js
+++ b/lib/mongorito.js
@@ -33,6 +33,12 @@ function Mongorito () {}
 
 
 /**
+* Expose MongoDb driver for external use (e.g. with GridFS)
+*/
+Mongorito.mongodb = mongodb;
+
+
+/**
  * Connect to a MongoDB database and return connection object
  *
  * @param {String} urls - connection urls (as arguments)


### PR DESCRIPTION
In order to be able to use Mongorito's connection with other modules like [GridFS-Stream](https://github.com/aheckmann/gridfs-stream) it's required to expose Mongorito's MongoDB driver.

Using this modification, it's possible to launch GridFS like that:

```javascript
        Mongorito._connection.then(db => {
            this._gfs = gridFs(db, Mongorito.mongodb);
        });
```

No need to specifically include MongoDb as dependency into the project and `import` it.