### PR TITLE
Fix array for _id in find with $in not being converted to ObjectId.

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -367,8 +367,8 @@ Query.prototype.find = function (query, options) {
 	let populate = Object.keys(options.populate);
 
 	// ensure _id is ObjectId
-	if (query._id && !is.object(query._id)) {
-		if (typeof query._id === 'object') {
+	if (query._id) {
+		if (is.object(query._id)) {
 			if (query._id.$in) {
 				let convertedIds = [];
 


### PR DESCRIPTION
A query to `find` documents by `_id` does not work. An example of this query is:
```javascript
const documents = await Model.find({ _id: { 
  $in: [ '576920dcde4ff8858d61efab', '576920dcde4ff8858d61efac' ] 
} } );¬
```

The whole parsing logic is skipped while using a query like `{ _id: '576920dcde4ff8858d61efab' }` gets parsed.