### PR TITLE
fix to-objectid

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongorito",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "ES6 generator-based MongoDB ODM. It rocks.",
   "author": "Vadim Demedes <vdemedes@gmail.com>",
   "dependencies": {
@@ -34,7 +34,7 @@
     "test": "xo && nyc ava --serial",
     "coveralls": "nyc report --reporter=text-lcov | coveralls"
   },
-  "repository": "vdemedes/mongorito",
+  "repository": "garrefa/mongorito",
   "keywords": [
     "mongo",
     "mongodb",

--- a/util/to-objectid.js
+++ b/util/to-objectid.js
@@ -23,5 +23,9 @@ function toObjectId (id) {
 		return id;
 	}
 
-	return new ObjectId(id);
+  try {
+    return new ObjectId(id);
+  } catch (error) {
+    return id;
+  }
 }


### PR DESCRIPTION
I have a couple of legacy mongo collections where _id is a Meteor Random and not ObjectId.
Since mongorito searches for _id in query and automatic converts the id to obj id I was having crash all the time when i try to search this collection. I tried with find({ _id }) too, but then i realize mongorito was converting to obj id in find too, which is nice feature.
This small change fix the crash problemas. If the user send a invalid _id, it will return null instead of crash. And it will still work with those collections where _id is not ObjectId.