### PR TITLE
Implementation of getter & setter for accessing MongoDB driver.

### DIFF
--- a/lib/mongorito.js
+++ b/lib/mongorito.js
@@ -6,7 +6,6 @@
 
 const isGeneratorFn = require('is-generator-fn');
 const pluralize = require('pluralize');
-const mongodb = require('mongodb');
 const Promise = require('bluebird');
 const extend = require('class-extend').extend;
 const result = require('lodash.result');
@@ -17,9 +16,11 @@ const set = require('set-value');
 const is = require('is_js');
 const co = require('co');
 
+let mongodb = require('mongodb');
+let MongoClient = mongodb.MongoClient;
+
 const Query = require('./query');
 
-const MongoClient = mongodb.MongoClient;
 const emptyObject = {};
 
 
@@ -31,6 +32,28 @@ const emptyObject = {};
 
 function Mongorito () {}
 
+/**
+ * Sets the driver.
+ *
+ * @api public
+ * @param      {object}  driver  The driver
+ */
+Mongorito.setDriver = function(driver) {
+	if (typeof driver !== 'undefined' && typeof driver.MongoClient !== 'undefined') {
+		mongodb = driver;
+		MongoClient = driver.MongoClient;
+	}
+};
+
+/**
+ * Gets the driver.
+ *
+ * @api public
+ * @return     {object}  The driver.
+ */
+Mongorito.getDriver = function() {
+	return mongodb;
+};
 
 /**
  * Connect to a MongoDB database and return connection object

--- a/test/attributes.js
+++ b/test/attributes.js
@@ -37,7 +37,7 @@ test('expose mongodb properties', t => {
 });
 
 test('set and get mongodb driver', t => {
-	let mockDriver = {
+	const mockDriver = {
 		'MongoClient': true
 	};
 
@@ -47,12 +47,10 @@ test('set and get mongodb driver', t => {
 });
 
 test('set mock mongodb driver and connect', t => {
-	let mockDriver = {
+	const mockDriver = {
 		'MongoClient': {
 			'connect': () => {
-				return new Promise(fulfill => {
-					return fulfill('ok');
-				});
+				return Promise.resolve('ok');
 			}
 		}
 	};

--- a/test/attributes.js
+++ b/test/attributes.js
@@ -36,6 +36,35 @@ test('expose mongodb properties', t => {
 	});
 });
 
+test('set and get mongodb driver', t => {
+	let mockDriver = {
+		'MongoClient': true
+	};
+
+	mongorito.setDriver(mockDriver);
+
+	t.is(mongorito.getDriver(), mockDriver);
+});
+
+test('set mock mongodb driver and connect', t => {
+	let mockDriver = {
+		'MongoClient': {
+			'connect': () => {
+				return new Promise(fulfill => {
+					return fulfill('ok');
+				});
+			}
+		}
+	};
+
+	mongorito.setDriver(mockDriver);
+
+	// If setDriver was not successful, Mongorito would use a real driver here, which would fail on the invalid connect
+	// URL. This means: If this connect is successful, setDriver was successful, as the mockDriver that was used always
+	// fulfills.
+	t.ok(mongorito.connect('THIS:IS:AN:INVALID:MONGO_URL'));
+});
+
 test('initialize and manage attributes', t => {
 	let data = postFixture();
 	let post = new Post(data);


### PR DESCRIPTION
@vdemedes @johannesboyne I re-worked what I did in #121 and I'd like to drop the previous PR and use this one instead.

@vdemedes the reason for this refactoring is that not only getting the MongoDB driver is important, but also setting it. In my use case, I would like to use @Opbeat for performance monitoring. Opbeat however expects that it gets the opportunity to "wrap" itself around the MongoDB driver. In order to do so, I'm required to initialise the MongoDB driver inside my project, have Opbeat wrap it and only then pass it through to Mongorito.

The getter on the other hand was discussed inside #121 and should be continued here. Thanks!