### PR TITLE
implement old way to create connection

### DIFF
--- a/src/database.js
+++ b/src/database.js
@@ -24,7 +24,7 @@ class Database {
 	}
 
 	static connect(urls, options) {
-		const db = new this(urls, options);
+		const db = new Database(urls, options);
 		db.connect();
 		return db;
 	}

--- a/src/database.js
+++ b/src/database.js
@@ -23,6 +23,12 @@ class Database {
 		this.plugins = [];
 	}
 
+	static connect(urls, options) {
+		const db = new this(urls, options);
+		db.connect();
+		return db;
+	}
+
 	connect() {
 		if (this._connection) {
 			return Promise.resolve(this._connection);


### PR DESCRIPTION
Allow v2 syntax on v3
```javascript
const db = mongorito.connect("mongodb://localhost/test", {});
```