### PR TITLE
Implement old way to create connection

### DIFF
--- a/src/database.js
+++ b/src/database.js
@@ -23,6 +23,16 @@ class Database {
 		this.plugins = [];
 	}
 
+	static connect(urls, options) {
+		const db = new this(urls, options);
+		const connection = db.connect();
+		db.then = function (success, reject) {
+			delete db.then;
+			return connection.then(success, reject);
+		};
+		return db;
+	}
+
 	connect() {
 		if (this._connection) {
 			return Promise.resolve(this._connection);


### PR DESCRIPTION
Allow v2 syntax on v3

```javascript
// Database instance
const db = mongorito.connect("mongodb://localhost/test", {});

// connection returned from db.connect
db.then(connection => console.log('Connected to database'));

// await db; in async function
```

sorry for the duplicate PR. Accidentally i deleted this branch